### PR TITLE
Fix blog post hover effect for light mode

### DIFF
--- a/components/Blog/Blog.tsx
+++ b/components/Blog/Blog.tsx
@@ -66,7 +66,7 @@ const Post: FC<BlogProps> = ({
   return (
     <Link href={`/blog/${slug}`} passHref locale={false}>
       <motion.a
-        className={`${tags} my-5 hover:bg-gray-800 p-7 rounded-lg transition-all`}
+        className={`${tags} my-5 hover:bg-gray-200 dark:hover:bg-gray-800 p-7 rounded-lg transition-all`}
         variants={Fade}
       >
         <h1 className='text-gray-900 dark:text-white text-2xl'>{title}</h1>


### PR DESCRIPTION
Here is a before and after:
![before-after](https://user-images.githubusercontent.com/44239968/181034213-21465b09-2ce3-435f-b18f-c338492729fa.png)
